### PR TITLE
Dev

### DIFF
--- a/wilc/Kconfig
+++ b/wilc/Kconfig
@@ -33,13 +33,13 @@ config WILC_SPI
 	  VDDIO. Select this if your platform is using the SPI bus.
 	  WILC3000 additionally supports BT 4.0 and BLE modes.
 
-config WILC1000_HW_OOB_INTR
-	bool "WILC1000 out of band interrupt"
-	depends on WILC1000_SDIO
+config WILC_HW_OOB_INTR
+	bool "WILC out of band interrupt"
+	depends on WILC_SDIO
 	default n
 	---help---
-	  This option enables out-of-band interrupt support for the WILC1000
-	  chipset. This OOB interrupt is intended to provide a faster interrupt
-	  mechanism for SDIO host controllers that don't support SDIO interrupt.
-	  Select this option If the SDIO host controller in your platform
-	  doesn't support SDIO time devision interrupt.
+	  This option enables out-of-band interrupt support for the WILC1000 &
+	  WILC3000 chipset. This OOB interrupt is intended to provide a faster
+	  interrupt mechanism for SDIO host controllers that don't support SDIO
+	  interrupt. Select this option If the SDIO host controller in your
+	  platform doesn't support SDIO time devision interrupt.

--- a/wilc/linux_wlan.c
+++ b/wilc/linux_wlan.c
@@ -29,6 +29,8 @@
 #include <linux/mmc/sdio_func.h>
 #include <linux/pm_runtime.h>
 
+#include <linux/of_gpio.h>
+
 #include "linux_wlan.h"
 
 #ifdef DISABLE_PWRSAVE_AND_SCAN_DURING_IP
@@ -40,9 +42,9 @@ void handle_pwrsave_during_obtainingIP(struct wilc_vif *vif, uint8_t state)
 {
 
 	switch(state)
-	{	
+	{
 	case IP_STATE_OBTAINING:
-		
+
 		PRINT_INFO(vif->ndev, GENERIC_DBG, "Obtaining an IP, Disable (Scan-Set PowerSave)\n");
 		PRINT_INFO(vif->ndev, GENERIC_DBG, "Save the Current state of the PS = %d\n", vif->pwrsave_current_state);
 
@@ -58,7 +60,7 @@ void handle_pwrsave_during_obtainingIP(struct wilc_vif *vif, uint8_t state)
 		mod_timer(&wilc_during_ip_timer, (jiffies + msecs_to_jiffies(20000)));
 
 		break;
-	
+
 	case IP_STATE_OBTAINED:
 
 		PRINT_INFO(vif->ndev, GENERIC_DBG, "IP obtained , Enable (Scan-Set PowerSave)\n");
@@ -72,10 +74,10 @@ void handle_pwrsave_during_obtainingIP(struct wilc_vif *vif, uint8_t state)
 			wilc_set_power_mgmt(vif, vif->pwrsave_current_state, 0);
 		}
 
-		del_timer(&wilc_during_ip_timer);	
+		del_timer(&wilc_during_ip_timer);
 
 		break;
-	
+
 	case IP_STATE_GO_ASSIGNING:
 
 		/* Set the wilc_optaining_ip flag */
@@ -86,7 +88,7 @@ void handle_pwrsave_during_obtainingIP(struct wilc_vif *vif, uint8_t state)
 		mod_timer(&wilc_during_ip_timer, (jiffies + msecs_to_jiffies(duringIP_TIME)));
 
 		break;
-	
+
 	default: //IP_STATE_DEFAULT
 
 		/* Clear the wilc_optaining_ip flag */
@@ -123,7 +125,7 @@ void store_power_save_current_state(struct wilc_vif *vif, bool val)
 void clear_duringIP(unsigned long arg)
 {
 	struct wilc_vif *vif = (struct wilc_vif *)arg;
-	
+
 	PRINT_ER(vif->ndev, "Unable to Obtain IP\n");
 
 	/* Clear the wilc_optaining_ip flag */
@@ -183,7 +185,7 @@ static int debug_thread(void *arg)
 	signed long timeout;
 	struct host_if_drv *hif_drv;
 	int i = 0;
-	
+
 	vif = netdev_priv(dev);
 
 	priv = wiphy_priv(vif->ndev->ieee80211_ptr->wiphy);
@@ -354,7 +356,7 @@ static int dev_state_ev_handler(struct notifier_block *this,
 			handle_pwrsave_during_obtainingIP(vif, IP_STATE_DEFAULT);
 		}
 
-		
+
 		wilc_resolve_disconnect_aberration(vif);
 
 		PRINT_INFO(vif->ndev, GENERIC_DBG, "[%s] Down IP\n", dev_iface->ifa_label);
@@ -438,42 +440,42 @@ static int init_irq(struct net_device *dev)
 	vif = netdev_priv(dev);
 	wl = vif->wilc;
 
-	if ((gpio_request(wl->gpio, "WILC_INTR") == 0) &&
-	    (gpio_direction_input(wl->gpio) == 0)) {
-		wl->dev_irq_num = gpio_to_irq(wl->gpio);
+	if ((gpio_request(wl->gpio_irq, "WILC_INTR") == 0) &&
+	    (gpio_direction_input(wl->gpio_irq) == 0)) {
+		wl->dev_irq_num = gpio_to_irq(wl->gpio_irq);
 	} else {
 		ret = -1;
 		PRINT_ER(dev, "could not obtain gpio for WILC_INTR\n");
 	}
 
-	if ((wl->io_type & 0x1) == HIF_SPI || 
+	if ((wl->io_type & 0x1) == HIF_SPI ||
 		(wl->io_type & 0x2) == HIF_SDIO_GPIO_IRQ) {
 		if (ret != -1 && request_threaded_irq(wl->dev_irq_num,
 						      isr_uh_routine,
 						      isr_bh_routine,
 						      IRQF_TRIGGER_LOW | IRQF_ONESHOT|IRQF_NO_SUSPEND,
 						      "WILC_IRQ", dev) < 0) {
-			PRINT_ER(dev, "Failed to request IRQ GPIO: %d\n", wl->gpio);
-			gpio_free(wl->gpio);
+			PRINT_ER(dev, "Failed to request IRQ GPIO: %d\n", wl->gpio_irq);
+			gpio_free(wl->gpio_irq);
 			ret = -1;
 		} else {
 			PRINT_INFO(dev, GENERIC_DBG,
 				   "IRQ request succeeded IRQ-NUM= %d on GPIO: %d\n",
-				   wl->dev_irq_num, wl->gpio);
+				   wl->dev_irq_num, wl->gpio_irq);
 			enable_irq_wake(wl->dev_irq_num);
 		}
 	} else {
-		if (ret != -1 && request_irq(wl->dev_irq_num, 
+		if (ret != -1 && request_irq(wl->dev_irq_num,
 						      host_wakeup_isr,
 						      IRQF_TRIGGER_FALLING | IRQF_NO_SUSPEND,
 						      "WILC_IRQ", dev) < 0) {
-			PRINT_ER(dev, "Failed to request IRQ GPIO: %d\n", wl->gpio);
-			gpio_free(wl->gpio);
+			PRINT_ER(dev, "Failed to request IRQ GPIO: %d\n", wl->gpio_irq);
+			gpio_free(wl->gpio_irq);
 			ret = -1;
 		} else {
 			PRINT_INFO(dev, GENERIC_DBG,
 				   "IRQ request succeeded IRQ-NUM= %d on GPIO: %d\n",
-				   wl->dev_irq_num, wl->gpio);
+				   wl->dev_irq_num, wl->gpio_irq);
 		}
 	}
 	return ret;
@@ -490,7 +492,7 @@ static void deinit_irq(struct net_device *dev)
 	/* Deinitialize IRQ */
 	if (wilc->dev_irq_num) {
 		free_irq(wilc->dev_irq_num, wilc);
-		gpio_free(wilc->gpio);
+		gpio_free(wilc->gpio_irq);
 	}
 }
 
@@ -532,10 +534,10 @@ void eap_buff_timeout(unsigned long user)
 {
     u8 null_bssid[ETH_ALEN] = {0};
     static u8 timeout = 5;
-    int status = -1; 
+    int status = -1;
     struct wilc_priv *priv;
     struct wilc_vif *vif ;
-	
+
     priv = (struct wilc_priv *)user;
     vif = netdev_priv(priv->dev);
     if (!(memcmp(priv->au8AssociatedBss, null_bssid, ETH_ALEN)) && (timeout-- > 0)) {
@@ -782,7 +784,7 @@ static int wilc_firmware_download(struct net_device *dev)
 		goto _fail_;
 
 	PRINT_INFO(vif->ndev, INIT_DBG, "Download Succeeded\n");
-	
+
 _fail_:
 	release_firmware(wilc->firmware);
 	wilc->firmware = NULL;
@@ -827,7 +829,7 @@ static int linux_wlan_init_test_config(struct net_device *dev,
 	c_val[0] = G_AUTO_PREAMBLE;
 	if (!wilc_wlan_cfg_set(vif, 0, WID_PREAMBLE, c_val, 1, 0, 0))
 		goto _fail_;
-	
+
 	c_val[0] = AUTO_PROT;
 	if (!wilc_wlan_cfg_set(vif, 0, WID_11N_PROT_MECH, c_val, 1, 0, 0))
 		goto _fail_;
@@ -970,7 +972,7 @@ static int linux_wlan_init_test_config(struct net_device *dev,
 	if (!wilc_wlan_cfg_set(vif, 0, WID_11N_RIFS_PROT_ENABLE, c_val, 1, 0,
 			       0))
 		goto _fail_;
-	
+
 	c_val[0] = 7;
 	if (!wilc_wlan_cfg_set(vif, 0, WID_11N_CURRENT_TX_MCS, c_val, 1, 0,
 			       0))
@@ -1072,7 +1074,7 @@ static int wlan_deinit_locks(struct net_device *dev)
 
 	vif = netdev_priv(dev);
 	wilc = vif->wilc;
-	
+
 	PRINT_INFO(vif->ndev, INIT_DBG, "De-Initializing Locks\n");
 
 	if (&wilc->hif_cs)
@@ -1080,7 +1082,7 @@ static int wlan_deinit_locks(struct net_device *dev)
 
 	if (&wilc->cs)
 		mutex_destroy(&wilc->cs);
-	
+
 	if (&wilc->rxq_cs)
 		mutex_destroy(&wilc->rxq_cs);
 
@@ -1130,7 +1132,7 @@ static void wlan_deinitialize_threads(struct net_device *dev)
 
 	vif = netdev_priv(dev);
 	wl = vif->wilc;
-	
+
 	PRINT_INFO(vif->ndev, INIT_DBG, "Deinitializing Threads\n");
 	if (!recovery_on) {
 		PRINT_INFO(vif->ndev, INIT_DBG, "Deinitializing debug Thread\n");
@@ -1173,7 +1175,7 @@ int wilc_wlan_initialize(struct net_device *dev, struct wilc_vif *vif)
 			goto _fail_locks_;
 		}
 		PRINT_INFO(vif->ndev, GENERIC_DBG, "WILC Initialization done\n");
-		if (wl->gpio >= 0 && init_irq(dev)) {
+		if (wl->gpio_irq >= 0 && init_irq(dev)) {
 			ret = -EIO;
 			goto _fail_locks_;
 		}
@@ -1267,7 +1269,7 @@ static int mac_init_fn(struct net_device *ndev)
 
 int wilc_bt_power_up(struct wilc *wilc, int source);
 int wilc_bt_power_down(struct wilc *wilc, int source);
-	
+
 static int wilc_mac_open(struct net_device *ndev)
 {
 	struct wilc_vif *vif;
@@ -1745,6 +1747,9 @@ int wilc_netdev_init(struct wilc **wilc, struct device *dev, int io_type,
 		     int gpio, const struct wilc_hif_func *ops)
 {
 	int i, ret;
+	int gpio_reset = -1;
+	int gpio_chip_en = -1;
+	int gpio_irq = -1;
 	struct wilc_vif *vif;
 	struct net_device *ndev;
 	struct wilc *wl;
@@ -1754,10 +1759,39 @@ int wilc_netdev_init(struct wilc **wilc, struct device *dev, int io_type,
 	if (!wl)
 		return -ENOMEM;
 
+	gpio_reset = of_get_named_gpio_flags(dev->of_node, "gpio_reset", 0, NULL);
+	if (gpio_reset < 0) {
+		ret = gpio_reset;
+		gpio_reset = GPIO_NUM_RESET;
+		dev_warn(dev, "WILC setting default Reset GPIO to %d.  Got %d\r\n", gpio_reset, ret);
+	} else {
+		dev_info(dev, "WILC got %d for gpio_reset\r\n", gpio_reset);
+	}
+
+	gpio_chip_en = of_get_named_gpio_flags(dev->of_node, "gpio_chip_en", 0, NULL);
+	if (gpio_chip_en < 0) {
+		ret = gpio_chip_en;
+		gpio_chip_en = GPIO_NUM_CHIP_EN;
+		dev_warn(dev, "WILC setting default Chip Enable GPIO to %d.  Got %d\r\n", gpio_chip_en, ret);
+	} else {
+		dev_info(dev, "WILC got %d for gpio_chip_en\r\n", gpio_chip_en);
+	}
+
+	gpio_irq = of_get_named_gpio_flags(dev->of_node, "gpio_irq", 0, NULL);
+	if (gpio_irq < 0) {
+		ret = gpio_irq;
+		gpio_irq = GPIO_NUM;
+		dev_warn(dev, "WILC setting default IRQ GPIO to %d.  Got %d\r\n", gpio_irq, ret);
+	} else {
+		dev_info(dev, "WILC got %d for gpio_irq\r\n", gpio_irq);
+	}
+
 	*wilc = wl;
 
 	wl->io_type = io_type;
-	wl->gpio = gpio;
+	wl->gpio_irq = gpio_irq;
+	wl->gpio_chip_en = gpio_chip_en;
+	wl->gpio_reset = gpio_reset;
 	wl->hif_func = ops;
 
 #ifdef DISABLE_PWRSAVE_AND_SCAN_DURING_IP
@@ -1820,36 +1854,36 @@ int wilc_netdev_init(struct wilc **wilc, struct device *dev, int io_type,
 }
 EXPORT_SYMBOL_GPL(wilc_netdev_init);
 
-static void wilc_wlan_power(int power)
+static void wilc_wlan_power(struct wilc *wilc, int power)
 {
 	pr_info("wifi_pm : %d \n", power);
-	if (gpio_request(GPIO_NUM_CHIP_EN, "CHIP_EN") == 0 &&
-	    gpio_request(GPIO_NUM_RESET, "RESET") == 0) {
-		gpio_direction_output(GPIO_NUM_CHIP_EN, 0);
-		gpio_direction_output(GPIO_NUM_RESET, 0);
+	if (gpio_request(wilc->gpio_chip_en, "CHIP_EN") == 0 &&
+	    gpio_request(wilc->gpio_reset, "RESET") == 0) {
+		gpio_direction_output(wilc->gpio_chip_en, 0);
+		gpio_direction_output(wilc->gpio_reset, 0);
 		if (power) {
-			gpio_set_value(GPIO_NUM_CHIP_EN, 1);
+			gpio_set_value(wilc->gpio_chip_en, 1);
 			mdelay(5);
-			gpio_set_value(GPIO_NUM_RESET, 1);
+			gpio_set_value(wilc->gpio_reset, 1);
 		} else {
-			gpio_set_value(GPIO_NUM_RESET, 0);
-			gpio_set_value(GPIO_NUM_CHIP_EN, 0);
+			gpio_set_value(wilc->gpio_reset, 0);
+			gpio_set_value(wilc->gpio_chip_en, 0);
 		}
-		gpio_free(GPIO_NUM_CHIP_EN);
-		gpio_free(GPIO_NUM_RESET);
+		gpio_free(wilc->gpio_chip_en);
+		gpio_free(wilc->gpio_reset);
 	}
 }
 
-void wilc_wlan_power_on_sequence(void)
+void wilc_wlan_power_on_sequence(struct wilc *wilc)
 {
-	wilc_wlan_power(0);
-	wilc_wlan_power(1);
+	wilc_wlan_power(wilc, 0);
+	wilc_wlan_power(wilc, 1);
 }
 EXPORT_SYMBOL_GPL(wilc_wlan_power_on_sequence);
 
-void wilc_wlan_power_off_sequence(void)
+void wilc_wlan_power_off_sequence(struct wilc *wilc)
 {
-	wilc_wlan_power(0);
+	wilc_wlan_power(wilc, 0);
 }
 EXPORT_SYMBOL_GPL(wilc_wlan_power_off_sequence);
 

--- a/wilc/wilc_bt.c
+++ b/wilc/wilc_bt.c
@@ -149,16 +149,16 @@ static void wilc_bt_create_device(void)
 		unregister_chrdev_region(chc_dev_no, 1);
 		return;
 	}
-	mutex_init(&wilc_bt->cs);	
+	mutex_init(&wilc_bt->cs);
 	device_created = 1;
 }
 
 static void wilc_cmd_handle_wilc_cca_threshold(char* param)
 {
 	int carrier_thrshold, noise_thrshold;
-	unsigned int carr_thrshold_frac, noise_thrshold_frac, carr_thrshold_int, 
+	unsigned int carr_thrshold_frac, noise_thrshold_frac, carr_thrshold_int,
 		noise_thrshold_int, reg;
-	
+
 	if(param == NULL) {
 		pr_err("Invalid parameter\n");
 		return;
@@ -172,7 +172,7 @@ static void wilc_cmd_handle_wilc_cca_threshold(char* param)
 			"to -62.5 and -82.6\n\n");
 		return;
 	}
-	
+
 	pr_info("Changing CCA noise threshold to %d and carrier thresholds to %d \n",
 		noise_thrshold, carrier_thrshold);
 
@@ -192,12 +192,12 @@ static void wilc_cmd_handle_wilc_cca_threshold(char* param)
 	reg &= ~(0x7FF0000);
 	reg |= ((noise_thrshold_frac & 0x7) | ((noise_thrshold_int & 0x1FF) << 3)) << 16;
 	wilc_bt->hif_func->hif_write_reg(wilc_bt, CCA_CTL_2, reg);
-	
+
 	wilc_bt->hif_func->hif_read_reg(wilc_bt, CCA_CTL_7, &reg);
 	reg &= ~(0x7FF0000);
 	reg |= ((carr_thrshold_frac & 0x7) | ((carr_thrshold_int & 0x1FF) << 3)) << 16;
 	wilc_bt->hif_func->hif_write_reg(wilc_bt, CCA_CTL_7, reg);
-	
+
 	return;
 }
 
@@ -206,7 +206,7 @@ int wilc_bt_power_up(struct wilc *wilc, int source)
 	int count=0;
 	int ret;
 	int reg;
-	
+
 	mutex_lock(&wilc->cs);
 
 	pr_debug("source: %s, current bus status Wifi: %d, BT: %d\n",
@@ -245,8 +245,8 @@ int wilc_bt_power_up(struct wilc *wilc, int source)
 					break;
 				}
 			}
-			/*An additional wait to give BT firmware time to do CPLL update as the time 
-			measured since the start of BT Fw till the end of function "rf_nmi_init_tuner" was 71.2 ms */	
+			/*An additional wait to give BT firmware time to do CPLL update as the time
+			measured since the start of BT Fw till the end of function "rf_nmi_init_tuner" was 71.2 ms */
 			msleep(100);
 		}
 	}
@@ -268,7 +268,7 @@ int wilc_bt_power_up(struct wilc *wilc, int source)
 		if(wilc->power_status[PWR_DEV_SRC_WIFI] == false)
 		{
 			acquire_bus(wilc, ACQUIRE_AND_WAKEUP,PWR_DEV_SRC_BT);
-		
+
 			ret = wilc->hif_func->hif_read_reg(wilc, WILC_COEXIST_CTL, &reg);
 			if (!ret) {
 				pr_err("[wilc start]: fail read reg %x ...\n", WILC_COEXIST_CTL);
@@ -310,8 +310,8 @@ int wilc_bt_power_up(struct wilc *wilc, int source)
 				pr_err( "[wilc start]: fail write reg %x ...\n", WILC_COE_AUTO_PS_OFF_NULL_PKT);
 				goto _fail_;
 			}
-			
-			release_bus(wilc, RELEASE_ALLOW_SLEEP, PWR_DEV_SRC_BT);	
+
+			release_bus(wilc, RELEASE_ALLOW_SLEEP, PWR_DEV_SRC_BT);
 		}
 
 		// Enable BT wakeup
@@ -437,7 +437,7 @@ int wilc_bt_power_down(struct wilc *wilc, int source)
 
 		bt_init_done=0;
 	}
-	
+
 	mutex_lock(&wilc->cs);
 
 	pr_info("source: %s, current bus status Wifi: %d, BT: %d\n",
@@ -455,7 +455,7 @@ int wilc_bt_power_down(struct wilc *wilc, int source)
 		pr_warn("Another device is preventing power down. request source is %s\n",
 			(source == PWR_DEV_SRC_WIFI ? "Wifi" : "BT"));
 	} else {
-		wilc_wlan_power_off_sequence();
+		wilc_wlan_power_off_sequence(wilc);
 	}
 	wilc->power_status[source] = false;
 
@@ -495,7 +495,7 @@ static void wilc_bt_firmware_download(struct wilc *wilc)
 	ret = wilc->hif_func->hif_write_reg(wilc, 0x4f0000, 0x71);
 	if (!ret) {
 		pr_err("[wilc start]: fail write reg 0x4f0000 ...\n");
-		release_bus(wilc,RELEASE_ALLOW_SLEEP, PWR_DEV_SRC_BT);	
+		release_bus(wilc,RELEASE_ALLOW_SLEEP, PWR_DEV_SRC_BT);
 		goto _fail_1;
 	}
 

--- a/wilc/wilc_sdio.c
+++ b/wilc/wilc_sdio.c
@@ -139,12 +139,6 @@ static int linux_sdio_probe(struct sdio_func *func,
 	int gpio, ret;
 	static bool init_power;
 
-	if (!init_power) {
-		wilc_wlan_power_on_sequence();
-		init_power = 1;
-	}
-
-	gpio = -1;
 	dev_dbg(&func->dev, "Initializing netdev\n");
 	ret = wilc_netdev_init(&wilc, &func->dev, HIF_SDIO, gpio,
 			       &wilc_hif_sdio);
@@ -152,6 +146,12 @@ static int linux_sdio_probe(struct sdio_func *func,
 		dev_err(&func->dev, "Couldn't initialize netdev\n");
 		return ret;
 	}
+
+	if (!init_power) {
+		wilc_wlan_power_on_sequence(wilc);
+		init_power = 1;
+	}
+
 	sdio_set_drvdata(func, wilc);
 	wilc->dev = &func->dev;
 
@@ -295,7 +295,7 @@ static void wilc_sdio_disable_interrupt(struct wilc *dev)
 	int ret;
 
 	dev_info(&func->dev, "wilc_sdio_disable_interrupt\n");
-	
+
 	if (sdio_intr_lock  == WILC_SDIO_HOST_IRQ_TAKEN)
 		wait_event_interruptible(sdio_intr_waitqueue,
 				   sdio_intr_lock == WILC_SDIO_HOST_NO_TAKEN);
@@ -729,7 +729,7 @@ static int sdio_init(struct wilc *wilc, bool resume)
 	int loop, ret;
 	u32 chipid;
 
-	dev_info(&func->dev, "SDIO speed: %d\n", 
+	dev_info(&func->dev, "SDIO speed: %d\n",
 		func->card->host->ios.clock);
 #ifndef WILC_SDIO_IRQ_GPIO
 	init_waitqueue_head(&sdio_intr_waitqueue);
@@ -837,7 +837,7 @@ static int sdio_init(struct wilc *wilc, bool resume)
 	}
 
 	g_sdio.is_init = true;
-	
+
 	return 1;
 
 _fail_:
@@ -1092,7 +1092,7 @@ static int sdio_clear_int_ext(struct wilc *wilc, u32 val)
 				goto _fail_;
 			}
 		}
-	}	
+	}
 
 	return 1;
 _fail_:

--- a/wilc/wilc_spi.c
+++ b/wilc/wilc_spi.c
@@ -125,27 +125,31 @@ static u8 crc7(u8 crc, const u8 *buffer, u32 len)
 
 static int wilc_bus_probe(struct spi_device *spi)
 {
-	int ret, gpio;
+	int ret;
+	static bool init_power;
 	struct wilc *wilc;
-	dev_info(&spi->dev, "spiModalias: %s, spiMax-Speed: %d\n", 
-			spi->modalias, spi->max_speed_hz);
-	wilc_wlan_power_on_sequence();
-	gpio = of_get_gpio(spi->dev.of_node, 0);
-	if (gpio < 0)
-		gpio = GPIO_NUM;
+	struct device *dev = &spi->dev;
 
-	ret = wilc_netdev_init(&wilc, NULL, HIF_SPI, GPIO_NUM, &wilc_hif_spi);
+	dev_info(&spi->dev, "spiModalias: %s, spiMax-Speed: %d\n",
+			spi->modalias, spi->max_speed_hz);
+
+	ret = wilc_netdev_init(&wilc, dev, HIF_SPI, GPIO_NUM, &wilc_hif_spi);
 	if (ret)
 		return ret;
 
+	if (!init_power) {
+		wilc_wlan_power_on_sequence(wilc);
+		init_power = 1;
+	}
+
 	spi_set_drvdata(spi, wilc);
 	wilc->dev = &spi->dev;
-	
+
 	mutex_init(&wilc->hif_cs);
 	mutex_init(&wilc->cs);
 	wilc_bt_init(wilc);
 	wilc_debugfs_init();
-	
+
 	dev_info(&spi->dev, "WILC SPI probe success\n");
 	return 0;
 }
@@ -162,7 +166,7 @@ static int wilc_spi_suspend(struct device *dev)
 {
 	struct spi_device *spi = to_spi_device(dev);
 	struct wilc *wilc = spi_get_drvdata(spi);
-	
+
 	dev_info(&spi->dev, "\n\n << SUSPEND >>\n\n");
 	mutex_lock(&wilc->hif_cs);
 	chip_wakeup(wilc, 0);
@@ -182,9 +186,9 @@ static int wilc_spi_resume(struct device *dev)
 {
 	struct spi_device *spi = to_spi_device(dev);
 	struct wilc *wilc = spi_get_drvdata(spi);
-	
+
 	dev_info(&spi->dev, "\n\n  <<RESUME>> \n\n");
-	
+
 	/*wake the chip to compelete the re-intialization*/
 	chip_wakeup(wilc, 0);
 
@@ -192,11 +196,11 @@ static int wilc_spi_resume(struct device *dev)
 		mutex_unlock(&wilc->hif_cs);
 
 	host_wakeup_notify(wilc, 0);
-	
+
 	mutex_lock(&wilc->hif_cs);
-		
+
 	chip_allow_sleep(wilc, 0);
-	
+
 	if (mutex_is_locked(&wilc->hif_cs))
 		mutex_unlock(&wilc->hif_cs);
 
@@ -208,8 +212,8 @@ static const struct of_device_id wilc_of_match[] = {
 	{}
 };
 MODULE_DEVICE_TABLE(of, wilc_of_match);
-static const struct dev_pm_ops wilc_spi_pm_ops = {	
-     .suspend = wilc_spi_suspend,    
+static const struct dev_pm_ops wilc_spi_pm_ops = {
+     .suspend = wilc_spi_suspend,
      .resume    = wilc_spi_resume,
     	};
 
@@ -795,7 +799,7 @@ _FAIL_:
 		dev_err(&spi->dev, "Reset and retry %d %x\n",retry, adr);
 		msleep(1);
 		retry--;
-		if(retry) 
+		if(retry)
 			goto _RETRY_;
 	}
 	return result;
@@ -825,7 +829,7 @@ _FAIL_:
 		dev_err(&spi->dev, "Reset and retry %d %x\n",retry, adr);
 		msleep(1);
 		retry--;
-		if(retry) 
+		if(retry)
 			goto _RETRY_;
 	}
 	return result;
@@ -846,7 +850,7 @@ static int wilc_spi_write_reg(struct wilc *wilc, u32 addr, u32 data)
 	u8 clockless = 0;
 
 	data = cpu_to_le32(data);
-_RETRY_:	
+_RETRY_:
 	if (addr <= 0x30) {
 		/* Clockless register*/
 		cmd = CMD_INTERNAL_WRITE;
@@ -860,7 +864,7 @@ _RETRY_:
 
 	result = spi_cmd_complete(wilc, cmd, addr, (u8 *)&data, 4, clockless);
 	if (result != N_OK) {
-		dev_err(&spi->dev, "Failed cmd, write reg (%08x)...\n", addr);		
+		dev_err(&spi->dev, "Failed cmd, write reg (%08x)...\n", addr);
 		goto _FAIL_;
 	}
 
@@ -871,7 +875,7 @@ _FAIL_:
 		dev_err(&spi->dev, "Reset and retry %d %x %d\n",retry, addr, data);
 		msleep(1);
 		retry--;
-		if(retry) 
+		if(retry)
 			goto _RETRY_;
 	}
 	return result;
@@ -893,7 +897,7 @@ static int wilc_spi_write(struct wilc *wilc, u32 addr, u8 *buf, u32 size)
 _RETRY_:
 	result = spi_cmd_complete(wilc, cmd, addr, NULL, size, 0);
 	if (result != N_OK) {
-		dev_err(&spi->dev, "Failed cmd, write block (%08x)...\n", addr);		
+		dev_err(&spi->dev, "Failed cmd, write block (%08x)...\n", addr);
 		goto _FAIL_;
 	}
 
@@ -913,7 +917,7 @@ _RETRY_:
 		dev_err(&spi->dev, "Failed block data write...\n");
 		goto _FAIL_;
 	}
-	
+
 _FAIL_:
 	if (result != N_OK)	{
 		msleep(1);
@@ -921,7 +925,7 @@ _FAIL_:
 		dev_err(&spi->dev, "Reset and retry %d %x %d\n",retry, addr, size);
 		msleep(1);
 		retry--;
-		if(retry) 
+		if(retry)
 			goto _RETRY_;
 	}
 	return result;
@@ -961,9 +965,9 @@ _FAIL_:
 		dev_warn(&spi->dev, "Reset and retry %d %x\n",retry, addr);
 		msleep(1);
 		retry--;
-		if(retry) 
+		if(retry)
 			goto _RETRY_;
-	}	
+	}
 	return result;
 }
 
@@ -991,7 +995,7 @@ _FAIL_:
 		dev_warn(&spi->dev, "Reset and retry %d %x %d\n",retry, addr, size);
 		msleep(1);
 		retry--;
-		if(retry) 
+		if(retry)
 			goto _RETRY_;
 	}
 	return result;
@@ -1007,10 +1011,10 @@ int wilc_spi_reset(struct wilc *wilc)
 {
 	struct spi_device *spi = to_spi_device(wilc->dev);
 	int result = N_OK;
-	
+
 	result = spi_cmd_complete(wilc, CMD_RESET, 0, 0 ,0, 0);
 	if (result != N_OK) {
-		dev_err(&spi->dev, "Failed cmd reset \n");	
+		dev_err(&spi->dev, "Failed cmd reset \n");
 		return 0;
 	}
 
@@ -1028,7 +1032,7 @@ static int _wilc_spi_deinit(struct wilc *wilc)
 	 *      TODO:
 	 **/
 	g_spi.is_init = false;
-	
+
 	return 1;
 }
 
@@ -1037,7 +1041,7 @@ static int wilc_spi_init(struct wilc *wilc, bool resume)
 	struct spi_device *spi = to_spi_device(wilc->dev);
 	u32 reg;
 	u32 chipid;
-	
+
 	if (g_spi.is_init) {
 		if (!wilc_spi_read_reg(wilc, 0x1000, &chipid)) {
 			dev_err(&spi->dev, "Fail cmd read chip id...\n");
@@ -1101,7 +1105,7 @@ static int wilc_spi_init(struct wilc *wilc, bool resume)
 		}
 		dev_dbg(&spi->dev, "chipid %08x\n", chipid);
 	}
-		
+
 _pass_:
 	g_spi.is_init = true;
 	return 1;

--- a/wilc/wilc_wfi_netdevice.h
+++ b/wilc/wilc_wfi_netdevice.h
@@ -170,7 +170,7 @@ struct wilc_vif {
 	struct host_if_drv *hif_drv;
 	struct net_device *ndev;
 	u8 ifc_id;
-	
+
 	sysfs_attr_group attr_sysfs;
 #ifdef DISABLE_PWRSAVE_AND_SCAN_DURING_IP
 	bool pwrsave_current_state;
@@ -181,7 +181,9 @@ struct wilc {
 	const struct wilc_hif_func *hif_func;
 	int io_type;
 	int mac_status;
-	int gpio;
+	int gpio_irq;
+	int gpio_reset;
+	int gpio_chip_en;
 	bool initialized;
 	int dev_irq_num;
 	int close;
@@ -202,7 +204,7 @@ struct wilc {
 	struct completion debug_thread_started;
 	struct task_struct *txq_thread;
 	struct task_struct *debug_thread;
-	
+
 	int quit;
 	int cfg_frame_in_use;
 	struct wilc_cfg_frame cfg_frame;

--- a/wilc/wilc_wlan.h
+++ b/wilc/wilc_wlan.h
@@ -328,8 +328,8 @@ void chip_allow_sleep(struct wilc *wilc, int source);
 void chip_wakeup(struct wilc *wilc, int source);
 int wilc_send_config_pkt(struct wilc_vif *vif, u8 mode, struct wid *wids,
 			 u32 count, u32 drv);
-void wilc_wlan_power_on_sequence(void);
-void wilc_wlan_power_off_sequence(void);
+void wilc_wlan_power_on_sequence(struct wilc *wilc);
+void wilc_wlan_power_off_sequence(struct wilc *wilc);
 
 void wilc_bt_init(struct wilc *wilc);
 void wilc_bt_deinit(void);


### PR DESCRIPTION
I noticed that the GPIO were hard coded in the driver files, whereas they should be passed from device tree of platform data for flexibility.  So I propose these changes to allow dts to contain the GPIO definitions.  Tested on the SAMA5D2-xplained board using the following dts entry:

spi1: spi@fc000000 {
	pinctrl-names = "default";
	pinctrl-0 = <&pinctrl_spi1_ioset3>;
	status = "okay";

	wilc_spi@0 {
		compatible = "atmel,wilc_spi";
		spi-max-frequency = <12000000>;
		reg = <0>;

		gpio_reset = <&pioA 16 0>;
		gpio_chip_en = <&pioA 117 0>;
		gpio_irq = <&pioA 115 0>;

		status = "okay";
	};
};